### PR TITLE
Change exposed Sets to Lists to preserve server-side ordering

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "env": {
+    "browser": true,
     "node": true,
     "es6": true,
     "mocha": true

--- a/lib/Siren.js
+++ b/lib/Siren.js
@@ -20,9 +20,9 @@ var client = new Client();
 class Siren extends Immutable.Record({
 	classes: Immutable.Set(),
 	properties: Immutable.Map(),
-	entities: Immutable.Set(),
+	entities: Immutable.List(),
 	actions: Immutable.Map(),
-	links: Immutable.Set()
+	links: Immutable.List()
 }) {
 	constructor(args) {
 		if (!args && Siren.empty) {
@@ -57,7 +57,7 @@ class Siren extends Immutable.Record({
 	 * Finds the @See {@link EmbeddedSubEntity}|{@link LinkedSubEntity} entities referenced by the provided rel.
 	 *
 	 * @param  {String} rel The relation to this Siren entity for the requested sub-entity.
-	 * @return {Immutable.Set}  Set of sub-entities matching the requested rel.
+	 * @return {Immutable.List}  List of sub-entities matching the requested rel.
 	 */
 	findEntitiesByRel(rel) {
 		return this.entities.filter(item => item.rels.contains(rel));
@@ -66,7 +66,7 @@ class Siren extends Immutable.Record({
 	/**
 	 * Returns the sub-entities on this Siren object which are embedded sub-entities.
 	 *
-	 * @return {Immutable.Set}     Set of embedded sub-entities.
+	 * @return {Immutable.List}     List of embedded sub-entities.
 	 */
 	get embeddedEntities() {
 		return this.entities
@@ -78,7 +78,7 @@ class Siren extends Immutable.Record({
 	 * Returns the sub-entities on this Siren object which are embedded sub-entities.
 	 *
 	 * @param  {String} rel 	Only entities with a relation to the parent siren matching this should be returned.
-	 * @return {Immutable.Set}  Set of embedded sub-entities which match thes provided rel.
+	 * @return {Immutable.List}  List of embedded sub-entities which match thes provided rel.
 	 */
 	embeddedEntitiesByRel(rel) {
 		return this.embeddedEntities
@@ -88,7 +88,7 @@ class Siren extends Immutable.Record({
 	/**
 	 * Returns the sub-entities on the Siren object which are linked sub-entities.
 	 *
-	 * @return {Immutable.Set}     Set of linked sub-entities on this Siren object.
+	 * @return {Immutable.List}     List of linked sub-entities on this Siren object.
 	 */
 	get linkedEntities() {
 		return this.entities
@@ -100,7 +100,7 @@ class Siren extends Immutable.Record({
 	 * Returns the set of linked sub-entities on the Siren object which match the requested rel.
 	 *
 	 * @param  {String} rel     Only entities with this relation to the parent siren should be returned.
-	 * @return {Immutable.Set}  Set of linked sub-entities which match the provided rel.
+	 * @return {Immutable.List}  List of linked sub-entities which match the provided rel.
 	 */
 	linkedEntitiesByRel(rel) {
 		return this.linkedEntities
@@ -133,7 +133,7 @@ class Siren extends Immutable.Record({
 			}
 
 			map.set('links',
-				new Immutable.Set(
+				new Immutable.List(
 					_.map(obj.links || [], (item) => new SirenLink(item.rel, SirenHelpers.processUrl(item.href, baseUrl), item.class))
 				)
 			);
@@ -146,7 +146,7 @@ class Siren extends Immutable.Record({
 			);
 
 			map.set('entities',
-				new Immutable.Set(
+				new Immutable.List(
 					_.map(obj.entities || [], (item) => item.href ? LinkedSubEntity.fromJson(item, baseUrl) : EmbeddedSubEntity.fromJson(item, baseUrl))
 				)
 			);

--- a/lib/SirenLink.js
+++ b/lib/SirenLink.js
@@ -21,6 +21,8 @@ class SirenLink extends Immutable.Record({
 	 * @param  {Array.<String>} rels - array of rel values for this link
 	 * @param  {String} href - URL that this link refers to.
 	 * @param   {Array.<String>} classes - Array of optional class names
+	 *
+	 * @return {SirenLink} Constructed SirenLink instance.
 	 */
 	constructor(rels, href, classes = []) {
 		super({rels: new Immutable.Set(rels), href: href, classes: new Immutable.Set(classes)});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-siren",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Siren client based built on top of superagent",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-siren",
-  "version": "0.1.13",
+  "version": "0.2.0",
   "description": "Siren client based built on top of superagent",
   "main": "dist/index.js",
   "scripts": {

--- a/test/SirenLinkSpec.js
+++ b/test/SirenLinkSpec.js
@@ -14,7 +14,7 @@ describe('SirenLink', () => {
 			beforeEach(() => {
 				rels = ['a', 'b'];
 				href = 'http://blah.com';
-				classes = [chance.string(), chance.string()]
+				classes = [chance.string(), chance.string()];
 
 				link = new SirenLink(rels, href, classes);
 			});


### PR DESCRIPTION
*Updated embedded and linked entities to expose as a list to preserve server ordering.
*Updated links to expose as list to preserve server ordering.
*Upgraded major version since changing to list is a backwards incompatible change.
