### PR TITLE
honor meaningful falsy values for action fields

### DIFF
--- a/lib/ActionField.js
+++ b/lib/ActionField.js
@@ -30,7 +30,7 @@ class ActionField extends Immutable.Record({
 			map.set('name', json.name || map.name);
 			map.set('title', json.title || map.title);
 			map.set('type', json.type || map.type);
-			map.set('value', (json.value === false || json.value === 0) ? json.value : json.value || map.value);
+			map.set('value', (json.value !== undefined) ? json.value : map.value);
 		});
 	}
 

--- a/lib/ActionField.js
+++ b/lib/ActionField.js
@@ -30,7 +30,7 @@ class ActionField extends Immutable.Record({
 			map.set('name', json.name || map.name);
 			map.set('title', json.title || map.title);
 			map.set('type', json.type || map.type);
-			map.set('value', json.value || map.value);
+			map.set('value', (json.value === false || json.value === 0) ? json.value : json.value || map.value);
 		});
 	}
 

--- a/lib/SirenAction.js
+++ b/lib/SirenAction.js
@@ -42,7 +42,7 @@ class SirenAction extends Immutable.Record({
 
 		const payload = {};
 
-		this.fields.forEach(f => { if(f.value || f.value === false || f.value === 0) payload[f.name] = f.value });
+		this.fields.forEach(f => { if(f.value !== undefined) payload[f.name] = f.value });
 		Immutable.fromJS(data).forEach((value, key) => payload[key] = value);
 
 		if (this.method.toLowerCase() === 'get') {

--- a/lib/SirenAction.js
+++ b/lib/SirenAction.js
@@ -42,7 +42,7 @@ class SirenAction extends Immutable.Record({
 
 		const payload = {};
 
-		this.fields.forEach(f => { if(f.value) payload[f.name] = f.value });
+		this.fields.forEach(f => { if(f.value || f.value === false || f.value === 0) payload[f.name] = f.value });
 		Immutable.fromJS(data).forEach((value, key) => payload[key] = value);
 
 		if (this.method.toLowerCase() === 'get') {

--- a/test/ActionFieldSpec.js
+++ b/test/ActionFieldSpec.js
@@ -96,5 +96,27 @@ describe('ActionField', () => {
 				expect(field.value).to.equal(json.value);
 			});
 		});
+		
+		describe('When the JSON structure includes a value of 0', () => {
+			beforeEach(() => {
+				json.value = 0;
+				act();
+			});
+
+			it('Should have the value set on the parsed ActionField', () => {
+				expect(field.value).to.equal(json.value);
+			});
+		});
+		
+		describe('When the JSON structure includes a value of false', () => {
+			beforeEach(() => {
+				json.value = false;
+				act();
+			});
+
+			it('Should have the value set on the parsed ActionField', () => {
+				expect(field.value).to.equal(json.value);
+			});
+		});
 	});
 });


### PR DESCRIPTION
I have run the build and test steps with no failures.  

The lint step produced sever errors similar to: `1:1  error  Parsing error: 'import' and 'export' may appear only with 'sourceType: module'`
