### PR TITLE
Set protocol based on socket type

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -81,7 +81,7 @@ class Client {
 			let baseUrl = null;
 
 			if (res.req && res.req.socket && res.req._headers && res.req._headers.host) {
-				var protocol = res.req.socket.encrypted ? 'https' : 'http';
+				var protocol = !!res.req.socket.encrypted ? 'https' : 'http';
 				baseUrl = new Uri({protocol: protocol, hostname: res.req._headers.host}).toString();
 				baseUrl = new Uri(res.req.path).absoluteTo(baseUrl).toString();
 			}

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -81,8 +81,9 @@ class Client {
 			//TODO: cannot assume http
 			let baseUrl = null;
 
-			if (res.req && res.req._headers && res.req._headers.host) {
-				baseUrl = new Uri({protocol: 'http', hostname: res.req._headers.host}).toString();
+			if (res.req && res.req.socket && res.req._headers && res.req._headers.host) {
+				var protocol = res.req.socket.encrypted ? 'https' : 'http';
+				baseUrl = new Uri({protocol: protocol, hostname: res.req._headers.host}).toString();
 				baseUrl = new Uri(res.req.path).absoluteTo(baseUrl).toString();
 			}
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -78,7 +78,6 @@ class Client {
 
 			//if we made it this far it's likely Node and have to do more work to parse
 
-			//TODO: cannot assume http
 			let baseUrl = null;
 
 			if (res.req && res.req.socket && res.req._headers && res.req._headers.host) {


### PR DESCRIPTION
Use tls.tlsSocket.encrypted to determine if request object is using a secure socket, and set protocol to "https" if so. Otherwise use "http".